### PR TITLE
Add Color function to access a color with a specific name

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,12 @@ all “blue” colors in the Wikipedia palette:
 colors = palette.Wikipedia.Filter("blue")
 ```
 
+You can access a color with a specific name using the `Color` function:
+
+```go
+color, ok = palette.Wikipedia.Color("Pastel blue")
+```
+
 Calling a palette’s `Name` function with a given color returns the name & distance
 of the closest (perceptually) matching color in it:
 

--- a/gamut.go
+++ b/gamut.go
@@ -12,6 +12,7 @@ import (
 // A Palette is a collection of colors
 type Palette struct {
 	colors map[color.Color]Colors
+	names  map[string]color.Color
 }
 
 // MixedWith mixes two palettes
@@ -27,6 +28,9 @@ func (g *Palette) AddColors(cc Colors) {
 	if g.colors == nil {
 		g.colors = make(map[color.Color]Colors)
 	}
+	if g.names == nil {
+		g.names = make(map[string]color.Color)
+	}
 
 	for _, c := range cc {
 		found := false
@@ -40,6 +44,8 @@ func (g *Palette) AddColors(cc Colors) {
 		if !found {
 			g.colors[c.Color] = append(g.colors[c.Color], c)
 		}
+
+		g.names[c.Name] = c.Color
 	}
 }
 
@@ -61,6 +67,12 @@ func (g Palette) Clamped(cc []color.Color) Colors {
 		r = append(r, nm[0])
 	}
 	return r
+}
+
+// Color returns the color with a specific name
+func (g Palette) Color(name string) (color.Color, bool) {
+	c, ok := g.names[name]
+	return c, ok
 }
 
 // Name returns the name of the closest matching color

--- a/gamut_test.go
+++ b/gamut_test.go
@@ -116,3 +116,21 @@ func TestFilter(t *testing.T) {
 		t.Errorf("Expected %d results, got %d", exp, len(cc))
 	}
 }
+
+func TestColor(t *testing.T) {
+	c, ok := p1.Color("Spray")
+	if !ok {
+		t.Errorf("Expected ok to be true")
+	}
+
+	exp, _ := colorful.Hex("#66d9ef")
+	cc, _ := colorful.MakeColor(c)
+	if exp.Hex() != cc.Hex() {
+		t.Errorf("Expected %s, got %s", exp.Hex(), cc.Hex())
+	}
+
+	_, ok = p1.Color("Foobar red")
+	if ok {
+		t.Errorf("Expected ok to be false")
+	}
+}

--- a/palette/palettes_test.go
+++ b/palette/palettes_test.go
@@ -88,3 +88,21 @@ func TestFilter(t *testing.T) {
 		t.Errorf("Expected %d results, got %d", exp, len(cc))
 	}
 }
+
+func TestColor(t *testing.T) {
+	c, ok := Wikipedia.Color("Pastel blue")
+	if !ok {
+		t.Errorf("Expected ok to be true")
+	}
+
+	exp, _ := colorful.Hex("#aec6cf")
+	cc, _ := colorful.MakeColor(c)
+	if exp.Hex() != cc.Hex() {
+		t.Errorf("Expected %s, got %s", exp.Hex(), cc.Hex())
+	}
+
+	_, ok = Wikipedia.Color("Foobar red")
+	if ok {
+		t.Errorf("Expected ok to be false")
+	}
+}


### PR DESCRIPTION
You can access a color with a specific name using the `Color` function:

```go
color, ok = palette.Wikipedia.Color("Pastel blue")
```